### PR TITLE
fix: [CI-13938]: action multiline output variables

### DIFF
--- a/plugin/github/workflow.go
+++ b/plugin/github/workflow.go
@@ -124,16 +124,14 @@ func getOutputVariables(prevStepId, outputFile string, outputVars []string) step
 	skip := len(outputFile) == 0 || len(outputVars) == 0
 	cmd := ""
 	for _, outputVar := range outputVars {
-		cmd += fmt.Sprintf("print('%s'+'='+'${{ steps.%s.outputs.%s }}'); ", outputVar, prevStepId, outputVar)
+		cmd += fmt.Sprintf("%s=${{ steps.%s.outputs.%s }}\n", outputVar, prevStepId, outputVar)
 	}
 
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		cmd = fmt.Sprintf("python3 -c \"%s\" > %s", cmd, outputFile)
-	} else if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" {
 		cmd = fmt.Sprintf("python -c \"%s\"", outputVarWinScript(
 			outputVars, prevStepId, outputFile))
 	} else {
-		cmd = fmt.Sprintf("python -c \"%s\" > %s", cmd, outputFile)
+		cmd = fmt.Sprintf("echo \"%s\" > %s", cmd, outputFile)
 	}
 
 	s := step{


### PR DESCRIPTION
We were using python to output these variables in a file, which was unnecessary and giving syntax issues with multiline variables. This code change just uses echo command to do the same thing.
<img width="1496" alt="Screenshot 2024-09-17 at 1 41 11 PM" src="https://github.com/user-attachments/assets/f05286e4-ae21-4eed-b191-9991a3623591">
<img width="1496" alt="Screenshot 2024-09-17 at 1 41 22 PM" src="https://github.com/user-attachments/assets/6d35221c-2cab-4c96-86d1-0b776ae69e28">

