### PR TITLE
[feat]: [CI-17150]: plugin changes to support binary sources as argum…

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 	flag.StringVar(&sha, "sha", "", "plugin commit")
 	flag.StringVar(&kind, "kind", "", "plugin kind")
 	flag.BoolVar(&downloadOnly, "download-only", false, "plugin downloadOnly")
+	flag.BoolVar(&disableClone, "disable-clone", false, "disable clone functionality")
 	flag.Var(&binarySources, "sources", "source urls to download binaries")
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -92,7 +92,6 @@ func main() {
 
 	// clone the plugin repository
 	var codedir string
-
 	if !disableClone {
 		clone := cloner.NewCache(cloner.NewDefault())
 		codedir, err = clone.Clone(ctx, repo, ref, sha)
@@ -107,7 +106,6 @@ func main() {
 	switch {
 	// execute harness plugin
 	case kind == "harness" || (kind == "" && harness.Is(codedir)):
-
 		if !disableClone {
 			slog.Info("detected harness plugin.yml")
 		}

--- a/main.go
+++ b/main.go
@@ -109,15 +109,19 @@ func main() {
 	case kind == "harness" || (kind == "" && harness.Is(codedir)):
 		if !disableClone {
 			slog.Info("detected harness plugin.yml")
+		} else {
+			slog.Info("clone is disabled for harness plugin")
 		}
 		execer := harness.Execer{
-			Source:       codedir,
-			Workdir:      workdir,
-			Ref:          ref,
-			Environ:      os.Environ(),
-			Stdout:       os.Stdout,
-			Stderr:       os.Stderr,
-			DownloadOnly: downloadOnly,
+			Source:        codedir,
+			Workdir:       workdir,
+			Ref:           ref,
+			Environ:       os.Environ(),
+			Stdout:        os.Stdout,
+			Stderr:        os.Stderr,
+			BinarySources: binarySources,
+			DisableClone:  disableClone,
+			DownloadOnly:  downloadOnly,
 		}
 		if err := execer.Exec(ctx); err != nil {
 			slog.Error("step failed", "error", err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/drone/plugin/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// Save original command line arguments and flags
+func saveOriginalFlags() []string {
+	oldArgs := make([]string, len(os.Args))
+	copy(oldArgs, os.Args)
+	return oldArgs
+}
+
+// Restore original command line arguments and flags
+func restoreOriginalFlags(oldArgs []string) {
+	os.Args = make([]string, len(oldArgs))
+	copy(os.Args, oldArgs)
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+}
+
+func TestFlagParsing(t *testing.T) {
+	// Save original flags
+	oldArgs := saveOriginalFlags()
+	defer restoreOriginalFlags(oldArgs)
+
+	tests := []struct {
+		name          string
+		args          []string
+		expectedFlags struct {
+			name          string
+			repo          string
+			ref           string
+			sha           string
+			kind          string
+			downloadOnly  bool
+			disableClone  bool
+			binarySources []string
+		}
+	}{
+		{
+			name: "all flags set",
+			args: []string{
+				"cmd",
+				"-name", "test-plugin",
+				"-repo", "github.com/test/repo",
+				"-ref", "main",
+				"-sha", "abc123",
+				"-kind", "harness",
+				"-download-only",
+				"-disable-clone",
+				"-sources", "source1;source2;source3",
+			},
+			expectedFlags: struct {
+				name          string
+				repo          string
+				ref           string
+				sha           string
+				kind          string
+				downloadOnly  bool
+				disableClone  bool
+				binarySources []string
+			}{
+				name:          "test-plugin",
+				repo:          "github.com/test/repo",
+				ref:           "main",
+				sha:           "abc123",
+				kind:          "harness",
+				downloadOnly:  true,
+				disableClone:  true,
+				binarySources: []string{"source1", "source2", "source3"},
+			},
+		},
+		{
+			name: "minimal flags",
+			args: []string{
+				"cmd",
+				"-name", "minimal-plugin",
+				"-repo", "github.com/test/minimal",
+			},
+			expectedFlags: struct {
+				name          string
+				repo          string
+				ref           string
+				sha           string
+				kind          string
+				downloadOnly  bool
+				disableClone  bool
+				binarySources []string
+			}{
+				name:          "minimal-plugin",
+				repo:          "github.com/test/minimal",
+				ref:           "",
+				sha:           "",
+				kind:          "",
+				downloadOnly:  false,
+				disableClone:  false,
+				binarySources: []string{},
+			},
+		},
+		{
+			name: "multiple sources",
+			args: []string{
+				"cmd",
+				"-name", "source-plugin",
+				"-sources", "source1;source2",
+				"-sources", "source3;source4",
+			},
+			expectedFlags: struct {
+				name          string
+				repo          string
+				ref           string
+				sha           string
+				kind          string
+				downloadOnly  bool
+				disableClone  bool
+				binarySources []string
+			}{
+				name:          "source-plugin",
+				repo:          "",
+				ref:           "",
+				sha:           "",
+				kind:          "",
+				downloadOnly:  false,
+				disableClone:  false,
+				binarySources: []string{"source1", "source2", "source3", "source4"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset flags for each test
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+			os.Args = tt.args
+
+			// Reset global variables
+			name = ""
+			repo = ""
+			ref = ""
+			sha = ""
+			kind = ""
+			downloadOnly = false
+			disableClone = false
+			binarySources = utils.CustomStringSliceFlag{}
+
+			// Parse flags
+			flag.StringVar(&name, "name", "", "plugin name")
+			flag.StringVar(&repo, "repo", "", "plugin repository")
+			flag.StringVar(&ref, "ref", "", "plugin reference")
+			flag.StringVar(&sha, "sha", "", "plugin commit")
+			flag.StringVar(&kind, "kind", "", "plugin kind")
+			flag.BoolVar(&downloadOnly, "download-only", false, "plugin downloadOnly")
+			flag.BoolVar(&disableClone, "disable-clone", false, "disable clone functionality")
+			flag.Var(&binarySources, "sources", "source urls to download binaries")
+			flag.Parse()
+
+			// Assert flag values
+			assert.Equal(t, tt.expectedFlags.name, name)
+			assert.Equal(t, tt.expectedFlags.repo, repo)
+			assert.Equal(t, tt.expectedFlags.ref, ref)
+			assert.Equal(t, tt.expectedFlags.sha, sha)
+			assert.Equal(t, tt.expectedFlags.kind, kind)
+			assert.Equal(t, tt.expectedFlags.downloadOnly, downloadOnly)
+			assert.Equal(t, tt.expectedFlags.disableClone, disableClone)
+			assert.Equal(t, tt.expectedFlags.binarySources, binarySources.GetValue())
+		})
+	}
+}

--- a/plugin/harness/execer.go
+++ b/plugin/harness/execer.go
@@ -26,8 +26,8 @@ type Execer struct {
 	Source        string // plugin source code directory
 	Workdir       string // pipeline working directory (aka workspace)
 	DownloadOnly  bool
-	binarySources utils.CustomStringSliceFlag
-	disableClone  bool
+	BinarySources utils.CustomStringSliceFlag
+	DisableClone  bool
 	Environ       []string
 	Stdout        io.Writer
 	Stderr        io.Writer
@@ -35,7 +35,7 @@ type Execer struct {
 
 // Exec executes a bitrise plugin.
 func (e *Execer) Exec(ctx context.Context) error {
-	if !e.disableClone {
+	if !e.DisableClone {
 		// parse the bitrise plugin yaml
 		out, err := parseFile(filepath.Join(e.Source, "plugin.yml"))
 		if err != nil {
@@ -65,8 +65,8 @@ func (e *Execer) Exec(ctx context.Context) error {
 		} else {
 			return e.runShellExecutable(ctx, out)
 		}
-	} else if len(e.binarySources.GetValue()) > 0 {
-		return e.runSourceExecutable(ctx, e.binarySources.GetValue())
+	} else if len(e.BinarySources.GetValue()) > 0 {
+		return e.runSourceExecutable(ctx, e.BinarySources.GetValue())
 	} else {
 		slog.Error("clone is disabled and binary sources are empty. Aborting")
 		return nil
@@ -286,8 +286,8 @@ func runCmds(ctx context.Context, cmds []*exec.Cmd, env []string, workdir string
 
 func (e *Execer) getBinarySources(source string, fallback string) []string {
 	var sources []string
-	if len(e.binarySources.GetValue()) > 0 {
-		sources = append(sources, e.binarySources.GetValue()...)
+	if len(e.BinarySources.GetValue()) > 0 {
+		sources = append(sources, e.BinarySources.GetValue()...)
 	}
 	if source != "" {
 		sources = append(sources, source)

--- a/plugin/harness/execer.go
+++ b/plugin/harness/execer.go
@@ -285,7 +285,7 @@ func runCmds(ctx context.Context, cmds []*exec.Cmd, env []string, workdir string
 }
 
 func (e *Execer) getBinarySources(source string, fallback string) []string {
-	var sources []string
+	sources := []string{}
 	if len(e.BinarySources.GetValue()) > 0 {
 		sources = append(sources, e.BinarySources.GetValue()...)
 	}

--- a/plugin/harness/execer_test.go
+++ b/plugin/harness/execer_test.go
@@ -1,0 +1,57 @@
+package harness
+
+import (
+	"testing"
+
+	"github.com/drone/plugin/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBinarySources(t *testing.T) {
+	tests := []struct {
+		name          string
+		source        string
+		fallback      string
+		binarySources []string
+		expected      []string
+	}{
+		{
+			name:          "all sources present",
+			source:        "main-source",
+			fallback:      "fallback-source",
+			binarySources: []string{"binary1", "binary2"},
+			expected:      []string{"binary1", "binary2", "main-source", "fallback-source"},
+		},
+		{
+			name:          "only main source",
+			source:        "main-source",
+			fallback:      "",
+			binarySources: []string{},
+			expected:      []string{"main-source"},
+		},
+		{
+			name:          "only binary sources",
+			source:        "",
+			fallback:      "",
+			binarySources: []string{"binary1", "binary2"},
+			expected:      []string{"binary1", "binary2"},
+		},
+		{
+			name:          "empty sources",
+			source:        "",
+			fallback:      "",
+			binarySources: []string{},
+			expected:      []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			execer := &Execer{
+				BinarySources: utils.CustomStringSliceFlag{Value: tt.binarySources},
+			}
+			result := execer.getBinarySources(tt.source, tt.fallback)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/utils/custom_string_slice.go
+++ b/utils/custom_string_slice.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"strings"
+)
+
+// CustomStringSliceFlag is like a regular StringSlice flag but with
+// semicolon as a delimiter
+type CustomStringSliceFlag struct {
+	Value []string
+}
+
+func (f *CustomStringSliceFlag) GetValue() []string {
+	if f.Value == nil {
+		return make([]string, 0)
+	}
+	return f.Value
+}
+
+func (f *CustomStringSliceFlag) String() string {
+	if f.Value == nil {
+		return ""
+	}
+	return strings.Join(f.Value, ";")
+}
+
+func (f *CustomStringSliceFlag) Set(v string) error {
+	for _, s := range strings.Split(v, ";") {
+		s = strings.TrimSpace(s)
+		f.Value = append(f.Value, s)
+	}
+	return nil
+}

--- a/utils/custom_string_slice_test.go
+++ b/utils/custom_string_slice_test.go
@@ -1,0 +1,91 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomStringSliceFlag_Set(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{""},
+		},
+		{
+			name:     "single value",
+			input:    "test",
+			expected: []string{"test"},
+		},
+		{
+			name:     "multiple values",
+			input:    "test1;test2;test3",
+			expected: []string{"test1", "test2", "test3"},
+		},
+		{
+			name:     "values with spaces",
+			input:    "test 1; test 2 ; test 3",
+			expected: []string{"test 1", "test 2", "test 3"},
+		},
+		{
+			name:     "empty values between delimiters",
+			input:    "test1;;test2",
+			expected: []string{"test1", "", "test2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flag := &CustomStringSliceFlag{}
+			err := flag.Set(tt.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, flag.Value)
+		})
+	}
+}
+
+func TestCustomStringSliceFlag_MultipleSet(t *testing.T) {
+	flag := &CustomStringSliceFlag{}
+
+	// Test multiple Set calls
+	inputs := []string{
+		"test1;test2",
+		"test3",
+		"test4;test5",
+	}
+
+	expected := []string{
+		"test1", "test2", "test3", "test4", "test5",
+	}
+
+	for _, input := range inputs {
+		err := flag.Set(input)
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, expected, flag.Value)
+}
+
+func TestCustomStringSliceFlag_Integration(t *testing.T) {
+	flag := &CustomStringSliceFlag{}
+
+	// Test the complete workflow
+	err := flag.Set("value1;value2")
+	assert.NoError(t, err)
+
+	err = flag.Set("value3")
+	assert.NoError(t, err)
+
+	// Test GetValue
+	values := flag.GetValue()
+	assert.Equal(t, []string{"value1", "value2", "value3"}, values)
+
+	// Test String
+	str := flag.String()
+	assert.Equal(t, "value1;value2;value3", str)
+}


### PR DESCRIPTION
added following flags for plugin 

disable-clone --> disables clone in plugin
sources --> provided binary sources to used for downloading binaries 

Testing : 

- backward compatability testing (Existing plugin behaviour will be same )
- tested the new flags 
- 
![Screenshot 2025-04-24 at 13 25 06](https://github.com/user-attachments/assets/9f89ae37-3ccd-4532-932f-dfc80d771b40)

<img width="1319" alt="Screenshot 2025-04-24 at 13 17 20" src="https://github.com/user-attachments/assets/dfbc2cf7-b808-44e6-9c70-7cc234d11393" />
<img width="1346" alt="Screenshot 2025-04-24 at 13 17 52" src="https://github.com/user-attachments/assets/5fceeb5f-3587-4203-9872-ffc3733dd9c0" />

<img width="1218" alt="Screenshot 2025-04-24 at 13 17 10" src="https://github.com/user-attachments/assets/7c465bed-c1a4-48d8-b8e1-d89a0a7791d4" />

