### PR TITLE
feat: [CI-21185]: Add Dockerfile and versioning support for plugin binary

### DIFF
--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -1,0 +1,2 @@
+DOCKER_FILE_PATH: /harness/plugin/docker/Dockerfile-plugin
+CONTEXT_PATH: /harness/plugin

--- a/docker/Dockerfile-plugin
+++ b/docker/Dockerfile-plugin
@@ -1,0 +1,73 @@
+# ---------------------------------------------------------#
+#                   Build Plugin Binary                    #
+# ---------------------------------------------------------#
+FROM us-west1-docker.pkg.dev/gar-setup/docker/golang:1.25-alpine3.21 as builder
+
+RUN apk add --no-cache git ca-certificates
+
+WORKDIR /app
+
+# Copy go module files first for better caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build arguments for version information and target platform
+ARG BUILD_VERSION
+ARG BUILD_TIME
+ARG COMMIT_SHA
+ARG BRANCH_NAME
+ARG TARGETOS=linux
+ARG TARGETARCH
+
+# Build the application for target platform
+# CGO is disabled for cross-compilation support
+# Version is set via BUILD_VERSION arg from Harness CI pipeline
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    set -e; \
+    if [ "${TARGETOS}" = "windows" ]; then \
+      CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+        -buildvcs=false \
+        -ldflags "-s -w -X github.com/drone/plugin/version.Version=${BUILD_VERSION}" \
+        -o /app/plugin.exe; \
+    else \
+      CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+        -ldflags "-s -w -X github.com/drone/plugin/version.Version=${BUILD_VERSION}" \
+        -o /app/plugin; \
+    fi
+
+# ---------------------------------------------------------#
+#                   Create final image                     #
+# ---------------------------------------------------------#
+FROM scratch
+
+WORKDIR /binaries
+
+# Copy the binary (handle both Linux/macOS and Windows)
+ARG TARGETOS
+COPY --from=builder /app/plugin* /binaries/
+
+# Build metadata labels
+ARG BUILD_VERSION
+ARG BUILD_TIME
+ARG COMMIT_SHA
+ARG BRANCH_NAME
+ARG TARGETARCH
+ARG TARGETOS
+
+LABEL org.opencontainers.image.title="Harness Plugin"
+LABEL org.opencontainers.image.description="Harness CI plugin executor binary"
+LABEL org.opencontainers.image.vendor="Harness Inc."
+LABEL org.opencontainers.image.created="${BUILD_TIME}"
+LABEL org.opencontainers.image.revision="${COMMIT_SHA}"
+LABEL org.opencontainers.image.source="https://github.com/drone/plugin"
+LABEL org.opencontainers.image.version="${BUILD_VERSION}"
+LABEL BUILD_VERSION="${BUILD_VERSION}"
+LABEL BUILD_TIME="${BUILD_TIME}"
+LABEL BRANCH_NAME="${BRANCH_NAME}"
+LABEL COMMIT_SHA="${COMMIT_SHA}"
+LABEL ARCHITECTURE="${TARGETARCH}"
+LABEL OS="${TARGETOS}"

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/drone/plugin/plugin/github"
 	"github.com/drone/plugin/plugin/harness"
 	"github.com/drone/plugin/utils"
+	"github.com/drone/plugin/version"
 )
 
 var (
@@ -28,12 +29,20 @@ var (
 	downloadOnly  bool                        // plugin won't be executed on setting this flag. Only source will be downloaded. Used for caching the plugin dependencies
 	disableClone  bool                        // plugin does not clone when this flag is enabled
 	binarySources utils.CustomStringSliceFlag // plugin uses these binary source urls in the same order to download the binaires
+	showVersion   bool                        // show version and exit
 )
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] != "" && os.Args[1] == "healthz" {
-		fmt.Println("OK")
-		return
+	// Handle special commands before flag parsing
+	if len(os.Args) > 1 && os.Args[1] != "" {
+		if os.Args[1] == "healthz" {
+			fmt.Println("OK")
+			return
+		}
+		if os.Args[1] == "-v" || os.Args[1] == "--version" {
+			fmt.Println(version.GetVersion())
+			return
+		}
 	}
 	ctx := context.Background()
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Harness Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package version
+
+// Version holds the build version, set via ldflags during build
+var Version string
+
+// GetVersion returns the current build version
+func GetVersion() string {
+	if Version == "" {
+		return "dev"
+	}
+	return Version
+}


### PR DESCRIPTION
## Summary
Add Dockerfile and versioning support for the plugin binary to enable Harness CI builds and Docker-based distribution.

## Changes
### Version Support
- ✅ Added `version/version.go` with `GetVersion()` pattern
  - Returns "dev" for local builds
  - Can be set via ldflags during Docker build
- ✅ Updated `main.go` to support `-v` and `--version` flags

### Docker Build
- ✅ Created `docker/Dockerfile-plugin` for building binary images
  - Multi-stage build using GAR `golang:1.25-alpine3.21`
  - Scratch-based final image with binary at `/binaries/plugin`
  - Supports cross-platform builds (linux/darwin/windows, amd64/arm64)
  - Version injected via `BUILD_VERSION` arg

### Harness CI Integration
- ✅ Added `config/manifest.yaml` for Harness CI pipeline

## Testing
```bash
# Without ldflags
go build && ./plugin -v
# Output: dev

# With ldflags
go build -ldflags "-X github.com/drone/plugin/version.Version=3.9.5-beta" && ./plugin -v
# Output: 3.9.5-beta
```

## Impact
This enables building `harness/harness-vm-runner-plugin` images that will be bundled into `harness-vm-runner-binaries` for VM injection.

## Dependencies
- Part of VM Runner binary modernization effort
- Follows pattern established in CI-21182 (lite-engine)
- Required for harness-vm-runner-binaries bundle

## JIRA
https://harness.atlassian.net/browse/CI-21185