### PR TITLE
feat: [CI-21185]: Add minimal Helm chart for build pipeline compliance

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.git/
+.gitignore

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: harness-vm-runner-plugin
+description: Harness VM Runner Plugin Binary
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+dependencies: []

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,5 @@
+This chart contains the Harness VM Runner Plugin binary.
+The binary is available in the Docker image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+
+This chart is not meant to be deployed as a Kubernetes application.
+It exists only to satisfy the build pipeline requirements.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,5 @@
+image:
+  registry: ""
+  repository: "harness-vm-runner-plugin"
+  tag: "latest"
+  pullPolicy: IfNotPresent

--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -1,2 +1,3 @@
 DOCKER_FILE_PATH: /harness/plugin/docker/Dockerfile-plugin
 CONTEXT_PATH: /harness/plugin
+HELM_CHART_SOURCE_DIRECTORY: /harness/plugin/chart


### PR DESCRIPTION
- Create dummy Helm chart in chart/ directory
- Chart contains only metadata, no deployable resources
- Add HELM_CHART_SOURCE_DIRECTORY to manifest.yaml
- Chart exists solely to satisfy build pipeline requirements for binary-only services