### PR TITLE
fix: [CI-21185]: Upgrade Go to 1.25.7 and run as non-root user

### DIFF
--- a/docker/Dockerfile-plugin
+++ b/docker/Dockerfile-plugin
@@ -1,9 +1,11 @@
 # ---------------------------------------------------------#
 #                   Build Plugin Binary                    #
 # ---------------------------------------------------------#
-FROM us-west1-docker.pkg.dev/gar-setup/docker/golang:1.25-alpine3.21 as builder
+FROM us-west1-docker.pkg.dev/gar-setup/docker/golang:1.25.7 as builder
 
-RUN apk add --no-cache git ca-certificates
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates git && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -44,11 +46,17 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # ---------------------------------------------------------#
 FROM scratch
 
+# Copy minimal passwd file for non-root user
+COPY --from=builder /etc/passwd /etc/passwd
+
 WORKDIR /binaries
 
 # Copy the binary (handle both Linux/macOS and Windows)
 ARG TARGETOS
 COPY --from=builder /app/plugin* /binaries/
+
+# Run as non-root user (nobody:nobody is typically uid:gid 65534:65534)
+USER 65534:65534
 
 # Build metadata labels
 ARG BUILD_VERSION


### PR DESCRIPTION
## Summary

Fixes critical security vulnerabilities by upgrading Go version and implementing non-root user execution.

## Security Fixes

### 1. Go Version Upgrade: 1.25 → 1.25.7

Addresses three CVEs:

| CVE | Severity | CVSS | Package | Description |
|-----|----------|------|---------|-------------|
| CVE-2025-68121 | Critical | 10.0 | crypto/tls | Session resumption vulnerability |
| CVE-2025-61726 | High | 7.5 | net/url | Unlimited query parameters |
| CVE-2025-61730 | Medium | 5.3 | crypto/tls | TLS 1.3 handshake boundary issue |

### 2. Non-Root User Implementation

- Container now runs as `nobody:nobody` (uid:gid 65534:65534)
- Prevents privilege escalation attacks
- Copied `/etc/passwd` for proper user resolution
- Improves overall container security posture

## Changes

**Dockerfile Updates:**
- Base image: `golang:1.25-alpine3.21` → `golang:1.25.7`
- Package manager: `apk` → `apt-get` (Go 1.25.7 uses Debian base)
- Added `USER 65534:65534` directive
- Added `COPY --from=builder /etc/passwd /etc/passwd`

## Testing

✅ **Build validation:**
- Docker image builds successfully
- Binary size: ~10MB (plugin binary)

✅ **Version check:**
```bash
docker run plugin-test:latest /binaries/plugin --version
# Output: test-1.0.0 (build version embedded via ldflags)
```

✅ **User validation:**
```bash
docker inspect plugin-test:latest --format='User: {{.Config.User}}'
# Output: User: 65534:65534
```

✅ **Permission validation:**
- Non-root user cannot write to restricted directories
- Permission denied for /nonexistent (expected behavior)

## Related

- Story: [CI-21185](https://harness.atlassian.net/browse/CI-21185)
- Branch format: `release/*` for Harness CI PATCH releases

[CI-21185]: https://harness.atlassian.net/browse/CI-21185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ