### PR TITLE
fix: [CI-21721]: Update Go toolchain to resolve CVE-2026-25679

### DIFF
--- a/docker/Dockerfile-plugin
+++ b/docker/Dockerfile-plugin
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------#
 #                   Build Plugin Binary                    #
 # ---------------------------------------------------------#
-FROM us-west1-docker.pkg.dev/gar-setup/docker/golang:1.25.7 as builder
+FROM us-west1-docker.pkg.dev/gar-setup/docker/golang:1.25.8 as builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates git && \

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/drone/plugin
 
 go 1.24.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/buildkite/yaml v2.1.0+incompatible


### PR DESCRIPTION
Updates Go toolchain to address security vulnerability:

- CVE-2026-25679 (HIGH): Incorrect IPv6 host literal parsing in net/url. Updated Go toolchain from v1.25.7 to v1.25.8

This vulnerability was published on March 6, 2026 and affects URL parsing for IPv6 addresses.

Note: CVE-2025-15558 in docker/cli v28.0.4 remains unresolved as upgrading to v29.2.0 would break compatibility with harness/nektos-act/v2 v2.0.0. This is a Windows-specific vulnerability with limited impact for Linux-only builds. Tracking upgrade when nektos-act supports docker/cli v29+.